### PR TITLE
[ztang]: Add get_account_info Method

### DIFF
--- a/src/exchanges/okx.rs
+++ b/src/exchanges/okx.rs
@@ -81,6 +81,24 @@ impl OkxExchange {
     }
 
     // Get Methods
+    pub async fn get_account_info(&self) -> Result<HashMap<String, String>, Error> {
+        let endpoint: &str = "/api/v5/account/balance";
+        let response = self.send_request("GET", endpoint, None).await?;
+        if response.is_empty() {
+            return Err(anyhow!("No data returned from the API"));
+        }
+
+        let mut result: HashMap<String, String> = HashMap::new();
+
+        for (key, value) in &response[0] {
+            if let DataValue::ValueString(string_value) = value {
+                result.insert(key.clone(), string_value.clone());
+            }
+        }
+
+        Ok(result)
+    }
+
     pub async fn get_balances(&self) -> Result<Vec<HashMap<String, String>>, Error> {
         let endpoint: &str = "/api/v5/account/balance";
         let response = self.send_request("GET", endpoint, None).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_requests() {
-        println!("Testing get_balances method.");
         let configs: HashMap<String, String> = read_configs("configs.json", "okx_account");
         let okx_exchange = OkxExchange::new(&configs);
+
+        println!("Testing get_account_info method.");
+        match okx_exchange.get_account_info().await {
+            Ok(account_info) => println!("Account info: {:?}", account_info),
+            Err(e) => println!("Error getting account info: {:?}", e),
+        }
+
+        println!("Testing get_balances method.");
         match okx_exchange.get_balances().await {
             Ok(balances) => {
                 println!("Balances: {:?}", balances);


### PR DESCRIPTION
### PR Summary

**Description:**
<!-- Provide a concise summary of what this PR does, including the motivation behind it. -->
This PR adds a get_account_info method for the OKX exchange to fetch basic account information including, total equity, maintenance margin ratio, available balance, leverage, etc. 

**Issue(s) Fixed:**
<!-- List any issues this PR addresses, using the format "Fixes #issue_number". If there are no related issues, state "None". -->

### Checklist

- [x] Manually tested changes
- [ ] Automated tests added/updated
- [ ] Reviewed changes
- [ ] Documentation updated (if applicable)

### Additional Notes
<!-- Add any additional notes or comments that might be helpful for the reviewer. -->
